### PR TITLE
fix: Use correct seeder path

### DIFF
--- a/src/infrastructure/configs/database.config.ts
+++ b/src/infrastructure/configs/database.config.ts
@@ -5,7 +5,7 @@ const database = {
   entities: ['src/**/*.orm-entity.ts'],
   migrationsTableName: 'migrations',
   migrations: ['src/**/migrations/*.ts'],
-  seeds: ['src/**/seeders/**/*.seeder.ts'],
+  seeds: ['src/**/seeding/**/*.seeder.ts'],
   factories: ['src/**/factories/**/*.ts'],
   cli: {
     migrationsDir: `src/infrastructure/database/migrations`,


### PR DESCRIPTION
Seeder that should be executed is located in /src/modules/user/database/**seeding**/user.seeder.ts. The config change should allow typeorm-seeding to find it.