### PR TITLE
Feat/add graphql adaptaters for finding users

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "class-validator": "^0.13.2",
     "dotenv": "^16.0.2",
     "env-var": "^7.3.0",
+    "graphql": "^16.6.0",
     "jest-cucumber": "^3.0.1",
     "nanoid": "^3.3.4",
     "nestjs-console": "^8.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,8 @@ import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ContextInterceptor } from './libs/application/context/ContextInterceptor';
 import { ExceptionInterceptor } from '@libs/application/interceptors/exception.interceptor';
 import { postgresConnectionUri } from './configs/database.config';
+import { GraphQLModule } from '@nestjs/graphql';
+import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 
 const interceptors = [
   {
@@ -29,6 +31,10 @@ const interceptors = [
       connectionUri: postgresConnectionUri,
     }),
     CqrsModule,
+    GraphQLModule.forRoot<ApolloDriverConfig>({
+      driver: ApolloDriver,
+      autoSchemaFile: true,
+    }),
 
     // Modules
     UserModule,

--- a/src/libs/api/graphql/paginated.graphql-response.base.ts
+++ b/src/libs/api/graphql/paginated.graphql-response.base.ts
@@ -1,0 +1,36 @@
+import { Field, ObjectType, Int } from '@nestjs/graphql';
+import { Type } from '@nestjs/common';
+// count limit page
+
+export interface IPaginatedType<T> {
+  data: T[];
+  count: number;
+  limit: number;
+  page: number;
+}
+
+export function PaginatedGraphqlResponse<T>(
+  classRef: Type<T>,
+): Type<IPaginatedType<T>> {
+  @ObjectType({ isAbstract: true })
+  abstract class PaginatedType implements IPaginatedType<T> {
+    constructor(props: IPaginatedType<T>) {
+      this.count = props.count;
+      this.limit = props.limit;
+      this.page = props.page;
+      this.data = props.data;
+    }
+    @Field(() => Int)
+    page: number;
+
+    @Field(() => Int)
+    count: number;
+
+    @Field()
+    limit: number;
+
+    @Field(() => [classRef])
+    readonly data: T[];
+  }
+  return PaginatedType as Type<IPaginatedType<T>>;
+}

--- a/src/libs/api/graphql/paginated.graphql-response.base.ts
+++ b/src/libs/api/graphql/paginated.graphql-response.base.ts
@@ -1,6 +1,5 @@
 import { Field, ObjectType, Int } from '@nestjs/graphql';
 import { Type } from '@nestjs/common';
-// count limit page
 
 export interface IPaginatedType<T> {
   data: T[];

--- a/src/modules/user/dtos/graphql/user.graphql-response.dto.ts
+++ b/src/modules/user/dtos/graphql/user.graphql-response.dto.ts
@@ -1,0 +1,30 @@
+import { ResponseBase } from '@libs/api/response.base';
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class UserGraphqlResponseDto extends ResponseBase {
+  @Field({
+    description: "User's identifier",
+  })
+  id: string;
+
+  @Field({
+    description: "User's email address",
+  })
+  email: string;
+
+  @Field({
+    description: "User's country of residence",
+  })
+  country: string;
+
+  @Field({
+    description: 'Postal code',
+  })
+  postalCode: string;
+
+  @Field({
+    description: 'Street where the user is registered',
+  })
+  street: string;
+}

--- a/src/modules/user/dtos/graphql/user.paginated-gql-response.dto.ts
+++ b/src/modules/user/dtos/graphql/user.paginated-gql-response.dto.ts
@@ -1,0 +1,12 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+import { PaginatedGraphqlResponse } from '../../../../libs/api/graphql/paginated.graphql-response.base';
+
+import { UserGraphqlResponseDto } from './user.graphql-response.dto';
+
+@ObjectType()
+export class UserPaginatedGraphqlResponseDto extends PaginatedGraphqlResponse(
+  UserGraphqlResponseDto,
+) {
+  @Field(() => [UserGraphqlResponseDto])
+  data: UserGraphqlResponseDto[];
+}

--- a/src/modules/user/queries/find-users/find-users.graphql-resolver.ts
+++ b/src/modules/user/queries/find-users/find-users.graphql-resolver.ts
@@ -1,0 +1,38 @@
+import { QueryBus } from '@nestjs/cqrs';
+import { Args, Query, Resolver } from '@nestjs/graphql';
+import { Result } from 'oxide.ts/dist';
+import { ResponseBase } from '../../../../libs/api/response.base';
+import { Paginated } from '../../../../libs/ddd';
+import { PaginatedParams } from '../../../../libs/ddd/query.base';
+import { UserModel } from '../../database/user.repository';
+import { UserPaginatedGraphqlResponseDto } from '../../dtos/graphql/user.paginated-gql-response.dto';
+import { FindUsersQuery } from './find-users.query-handler';
+
+@Resolver()
+export class FindUsersGraphqlResolver {
+  constructor(private readonly queryBus: QueryBus) {}
+  @Query(() => UserPaginatedGraphqlResponseDto)
+  async findUsers(
+    @Args('options', { type: () => String })
+    options: PaginatedParams<FindUsersQuery>,
+  ): Promise<UserPaginatedGraphqlResponseDto> {
+    const query = new FindUsersQuery(options);
+    const result: Result<
+      Paginated<UserModel>,
+      Error
+    > = await this.queryBus.execute(query);
+
+    const paginated = result.unwrap();
+    const response = new UserPaginatedGraphqlResponseDto({
+      ...paginated,
+      data: paginated.data.map((user) => ({
+        ...new ResponseBase(user),
+        email: user.email,
+        country: user.country,
+        street: user.street,
+        postalCode: user.postalCode,
+      })),
+    });
+    return response;
+  }
+}

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -12,6 +12,7 @@ import { FindUsersQueryHandler } from './queries/find-users/find-users.query-han
 import { UserMapper } from './user.mapper';
 import { CqrsModule } from '@nestjs/cqrs';
 import { USER_REPOSITORY } from './user.di-tokens';
+import { FindUsersGraphqlResolver } from './queries/find-users/find-users.graphql-resolver';
 
 const httpControllers = [
   CreateUserHttpController,
@@ -23,7 +24,10 @@ const messageControllers = [CreateUserMessageController];
 
 const cliControllers: Provider[] = [CreateUserCliController];
 
-const graphqlResolvers: Provider[] = [CreateUserGraphqlResolver];
+const graphqlResolvers: Provider[] = [
+  CreateUserGraphqlResolver,
+  FindUsersGraphqlResolver,
+];
 
 const commandHandlers: Provider[] = [CreateUserService, DeleteUserService];
 


### PR DESCRIPTION
Hi !
I found your repo very inspiring. I went ahead and dug more into the graphql side of it, as the current examples aren't "wired" yet to work correctly in nest.
I also added the option to query users.
Here is what it looks like in the graphql interface (available at localhost:3000/graphql) : 
![image](https://user-images.githubusercontent.com/18481465/221241513-edc971d7-1ef9-4113-94cc-33bd27cf07d3.png)

Some of the code is inspired from https://docs.nestjs.com/graphql/resolvers#class-inheritance 