### PR TITLE
replacement of v4() with native function randomUUID

### DIFF
--- a/src/libs/ddd/command.base.ts
+++ b/src/libs/ddd/command.base.ts
@@ -1,5 +1,4 @@
 import { RequestContextService } from '@libs/application/context/AppRequestContext';
-import { v4 } from 'uuid';
 import { ArgumentNotProvidedException } from '../exceptions';
 import { Guard } from '../guard';
 
@@ -43,7 +42,7 @@ export class Command {
       );
     }
     const ctx = RequestContextService.getContext();
-    this.id = props.id || v4();
+    this.id = props.id || crypto.randomUUID();
     this.metadata = {
       correlationId: props?.metadata?.correlationId || ctx.requestId,
       causationId: props?.metadata?.causationId,

--- a/src/libs/ddd/domain-event.base.ts
+++ b/src/libs/ddd/domain-event.base.ts
@@ -1,6 +1,5 @@
 import { ArgumentNotProvidedException } from '../exceptions';
 import { Guard } from '../guard';
-import { v4 } from 'uuid';
 import { RequestContextService } from '@libs/application/context/AppRequestContext';
 
 type DomainEventMetadata = {
@@ -41,7 +40,7 @@ export abstract class DomainEvent {
         'DomainEvent props should not be empty',
       );
     }
-    this.id = v4();
+    this.id = crypto.randomUUID();
     this.aggregateId = props.aggregateId;
     this.metadata = {
       correlationId:

--- a/src/modules/user/domain/user.entity.ts
+++ b/src/modules/user/domain/user.entity.ts
@@ -7,7 +7,6 @@ import {
   UserProps,
   UserRoles,
 } from './user.types';
-import { v4 } from 'uuid';
 import { UserDeletedDomainEvent } from './events/user-deleted.domain-event';
 import { UserRoleChangedDomainEvent } from './events/user-role-changed.domain-event';
 import { UserAddressUpdatedDomainEvent } from './events/user-address-updated.domain-event';
@@ -16,7 +15,7 @@ export class UserEntity extends AggregateRoot<UserProps> {
   protected readonly _id: AggregateID;
 
   static create(create: CreateUserProps): UserEntity {
-    const id = v4();
+    const id = crypto.randomUUID();
     /* Setting a default role since we are not accepting it during creation. */
     const props: UserProps = { ...create, role: UserRoles.guest };
     const user = new UserEntity({ id, props });

--- a/src/modules/wallet/domain/wallet.entity.ts
+++ b/src/modules/wallet/domain/wallet.entity.ts
@@ -1,7 +1,6 @@
 import { AggregateID, AggregateRoot } from '@libs/ddd';
 import { ArgumentOutOfRangeException } from '@libs/exceptions';
 import { Err, Ok, Result } from 'oxide.ts';
-import { v4 } from 'uuid';
 import { WalletCreatedDomainEvent } from './events/wallet-created.domain-event';
 import { WalletNotEnoughBalanceError } from './wallet.errors';
 
@@ -17,7 +16,7 @@ export class WalletEntity extends AggregateRoot<WalletProps> {
   protected readonly _id: AggregateID;
 
   static create(create: CreateWalletProps): WalletEntity {
-    const id = v4();
+    const id = crypto.randomUUID();
     const props: WalletProps = { ...create, balance: 0 };
     const wallet = new WalletEntity({ id, props });
 


### PR DESCRIPTION
To avoid contaminating the domain layer with external libraries, I would recommend using a native function to generate the UUID. Besides, this is a much faster alternative according to benchmarks:
https://medium.com/@matynelawani/uuid-vs-crypto-randomuuid-vs-nanoid-313e18144d8c